### PR TITLE
let images know, that they were loaded from memory cache

### DIFF
--- a/library/src/com/nostra13/universalimageloader/core/ImageLoader.java
+++ b/library/src/com/nostra13/universalimageloader/core/ImageLoader.java
@@ -236,6 +236,8 @@ public class ImageLoader {
 		if (bmp != null && !bmp.isRecycled()) {
 			if (configuration.writeLogs) L.d(LOG_LOAD_IMAGE_FROM_MEMORY_CACHE, memoryCacheKey);
 
+            listener.onLoadedFromMemoryCache();
+
 			if (options.shouldPostProcess()) {
 				ImageLoadingInfo imageLoadingInfo = new ImageLoadingInfo(uri, imageAware, targetSize, memoryCacheKey,
 						options, listener, progressListener, engine.getLockForUri(uri));

--- a/library/src/com/nostra13/universalimageloader/core/listener/ImageLoadingListener.java
+++ b/library/src/com/nostra13/universalimageloader/core/listener/ImageLoadingListener.java
@@ -64,4 +64,9 @@ public interface ImageLoadingListener {
 	 * @param view     View for image. Can be <b>null</b>.
 	 */
 	void onLoadingCancelled(String imageUri, View view);
+
+    /**
+     * Is called when image was taken from memory cache, i.e. was cached
+     */
+    void onLoadedFromMemoryCache();
 }

--- a/library/src/com/nostra13/universalimageloader/core/listener/SimpleImageLoadingListener.java
+++ b/library/src/com/nostra13/universalimageloader/core/listener/SimpleImageLoadingListener.java
@@ -47,4 +47,9 @@ public class SimpleImageLoadingListener implements ImageLoadingListener {
 	public void onLoadingCancelled(String imageUri, View view) {
 		// Empty implementation
 	}
+
+    @Override
+    public void onLoadedFromMemoryCache() {
+        // Empty implementation
+    }
 }


### PR DESCRIPTION
ImageLoadingListener now notifies that image was taken from memory cache